### PR TITLE
feat: FOVに応じたカメラオフセットで広角時に全天球を見渡しやすく

### DIFF
--- a/src/constants/camera.ts
+++ b/src/constants/camera.ts
@@ -51,3 +51,9 @@ export const MIN_ALTITUDE = -Math.PI / 2 + 0.1;
  * 最大高度角（ラジアン）- 天頂の少し下
  */
 export const MAX_ALTITUDE = Math.PI / 2 - 0.1;
+
+/**
+ * カメラオフセットの最大値（天球半径 = 1.0 に対する比率） FOVが最大のとき、この値だけ視線方向の逆方向にオフセット
+ * 広角時に全天球を見渡しやすくするための設定
+ */
+export const MAX_CAMERA_OFFSET = 0.5;

--- a/src/constants/rendering.ts
+++ b/src/constants/rendering.ts
@@ -18,9 +18,9 @@ export const BLOOM_RESOLUTION_SCALE = 0.5;
 export const MAX_DEVICE_PIXEL_RATIO = 2;
 
 /**
- * Uniform バッファサイズ
+ * Uniform バッファサイズ（12 floats = 48 bytes、16バイトアライメントで48バイト）
  */
-export const UNIFORM_BUFFER_SIZE = 64;
+export const UNIFORM_BUFFER_SIZE = 48;
 
 /**
  * 1星あたりのバイト数（4 floats）
@@ -43,9 +43,9 @@ export const CONSTELLATION_LINE_WIDTH = 0.002;
 export const CONSTELLATION_LINE_ALPHA = 0.6;
 
 /**
- * 星座線用Uniformバッファサイズ（8 floats）
+ * 星座線用Uniformバッファサイズ（12 floats）
  */
-export const CONSTELLATION_UNIFORM_SIZE = 32;
+export const CONSTELLATION_UNIFORM_SIZE = 48;
 
 /**
  * 操作ヒントの表示時間（ミリ秒）

--- a/src/lib/webgpu/bloom.ts
+++ b/src/lib/webgpu/bloom.ts
@@ -96,9 +96,9 @@ export function createPostProcessBindGroups(
 	sampler: GPUSampler,
 	skylineResources: SkylineResources,
 ): PostProcessBindGroups {
-	// 背景用uniformバッファ（カメラ情報：altitude, fov, aspect, azimuth）
+	// 背景用uniformバッファ（カメラ情報：altitude, fov, aspect, azimuth, minFov, maxFov, maxCameraOffset, padding）
 	const backgroundUniformBuffer = device.createBuffer({
-		size: 16, // 4 floats
+		size: 32, // 8 floats
 		usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
 	});
 
@@ -140,9 +140,9 @@ export function createPostProcessBindGroups(
 		],
 	});
 
-	// シルエット用uniformバッファ（カメラ情報：altitude, fov, aspect, azimuth）
+	// シルエット用uniformバッファ（カメラ情報：altitude, fov, aspect, azimuth, minFov, maxFov, maxCameraOffset, padding）
 	const silhouetteUniformBuffer = device.createBuffer({
-		size: 16, // 4 floats
+		size: 32, // 8 floats
 		usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
 	});
 

--- a/src/lib/webgpu/shaders/background.wgsl.ts
+++ b/src/lib/webgpu/shaders/background.wgsl.ts
@@ -8,10 +8,14 @@ export const backgroundShaderCode = /* wgsl */ `
 @group(0) @binding(0) var<uniform> camera: CameraUniforms;
 
 struct CameraUniforms {
-  altitude: f32,     // 視線の高度角 (ラジアン)
-  fov: f32,          // 視野角 (ラジアン)
-  aspect: f32,       // アスペクト比
-  azimuth: f32,      // 方位角 (ラジアン)
+  altitude: f32,        // 視線の高度角 (ラジアン)
+  fov: f32,             // 視野角 (ラジアン)
+  aspect: f32,          // アスペクト比
+  azimuth: f32,         // 方位角 (ラジアン)
+  minFov: f32,          // 最小視野角
+  maxFov: f32,          // 最大視野角
+  maxCameraOffset: f32, // カメラオフセット最大値
+  padding: f32,         // 16バイトアライメント用パディング
 }
 
 ${inversePerspectiveFunctions}
@@ -53,8 +57,8 @@ fn calculateSkyglow(pixelAltitude: f32) -> vec3f {
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
-  // UV座標から正確な高度を計算（透視投影の逆変換）
-  let horizontal = uvToHorizontal(input.uv, camera.azimuth, camera.altitude, camera.fov, camera.aspect);
+  // UV座標から正確な高度を計算（透視投影の逆変換、カメラオフセット対応）
+  let horizontal = uvToHorizontal(input.uv, camera.azimuth, camera.altitude, camera.fov, camera.aspect, camera.minFov, camera.maxFov, camera.maxCameraOffset);
   let pixelAltitude = horizontal.y;
   
   // 街明かりの光害を計算

--- a/src/lib/webgpu/shaders/silhouette.wgsl.ts
+++ b/src/lib/webgpu/shaders/silhouette.wgsl.ts
@@ -17,10 +17,14 @@ export const silhouetteShaderCode = /* wgsl */ `
 @group(0) @binding(1) var skylineTexture: texture_2d<f32>;
 
 struct CameraUniforms {
-  altitude: f32,     // 視線の高度角 (ラジアン)
-  fov: f32,          // 視野角 (ラジアン)
-  aspect: f32,       // アスペクト比
-  azimuth: f32,      // 方位角 (ラジアン)
+  altitude: f32,        // 視線の高度角 (ラジアン)
+  fov: f32,             // 視野角 (ラジアン)
+  aspect: f32,          // アスペクト比
+  azimuth: f32,         // 方位角 (ラジアン)
+  minFov: f32,          // 最小視野角
+  maxFov: f32,          // 最大視野角
+  maxCameraOffset: f32, // カメラオフセット最大値
+  padding: f32,         // 16バイトアライメント用パディング
 }
 
 const TWO_PI: f32 = 6.28318530718;
@@ -60,8 +64,8 @@ fn getSkylineHeight(azimuth: f32, layer: u32) -> f32 {
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
-  // UV座標から正確な方位角・高度を計算（透視投影の逆変換）
-  let horizontal = uvToHorizontal(input.uv, camera.azimuth, camera.altitude, camera.fov, camera.aspect);
+  // UV座標から正確な方位角・高度を計算（透視投影の逆変換、カメラオフセット対応）
+  let horizontal = uvToHorizontal(input.uv, camera.azimuth, camera.altitude, camera.fov, camera.aspect, camera.minFov, camera.maxFov, camera.maxCameraOffset);
   let pixelAzimuth = horizontal.x;
   let pixelAltitude = horizontal.y;
   


### PR DESCRIPTION
## Summary

視野角(FOV)に応じてカメラ位置を天球の中心からオフセットすることで、広角時に全天球を見渡しやすくしました。

## 変更内容

- FOVが大きくなるほど、カメラを視線方向の逆側（後ろ）にオフセット
- オフセット量: `MAX_CAMERA_OFFSET × (fov - MIN_FOV) / (MAX_FOV - MIN_FOV)`
  - FOV = 30度（最小）: オフセット = 0
  - FOV = 120度（最大）: オフセット = 0.5（天球半径の50%）
- 星、星座線、背景グラデーション、建物シルエットの全シェーダーに対応

## 技術的詳細

- Uniform構造体を拡張（`minFov`, `maxFov`, `maxCameraOffset` を追加）
- シェーダー内でカメラ位置からのレイを計算し、天球との交点を求める方式
- 背景/シルエットでは逆透視投影時に球面交差計算を実装

## 視覚的効果

広角（FOV = 120度）で上を見上げたとき、視点が少し後ろにオフセットされるため、より広い範囲の星空を見渡すことができます。